### PR TITLE
incorporacion de TablaColumna, para indice-generico

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -27,6 +27,10 @@ import { ListaRolComponent } from './features/rol/lista-rol/lista-rol.component'
 import { CrearRolComponent } from './features/rol/crear-rol/crear-rol.component';
 import { EditarRolComponent } from './features/rol/editar-rol/editar-rol.component';
 import { IndiceRolComponent } from './features/rol/indice-rol/indice-rol.component';
+import { ListaEmpresaComponent } from './features/empresa/lista-empresa/lista-empresa.component';
+import { IndiceEmpresaComponent } from './features/empresa/indice-empresa/indice-empresa.component';
+import { CrearEmpresaComponent } from './features/empresa/crear-empresa/crear-empresa.component';
+import { EditarEmpresaComponent } from './features/empresa/editar-empresa/editar-empresa.component';
 
 export const routes: Routes = [
   {
@@ -90,6 +94,15 @@ export const routes: Routes = [
       { path: 'listado', component: IndiceRolComponent },
       { path: 'crear', component: CrearRolComponent },
       { path: 'editar/:id', component: EditarRolComponent }
+    ]
+  },
+  {
+    path: 'empresa',
+    children: [
+      { path: '', component: ListaEmpresaComponent },
+      { path: 'listado', component: IndiceEmpresaComponent },
+      { path: 'crear', component: CrearEmpresaComponent },
+      { path: 'editar/:id', component: EditarEmpresaComponent }
     ]
   }
 

--- a/src/app/features/area/indice-area/indice-area.component.ts
+++ b/src/app/features/area/indice-area/indice-area.component.ts
@@ -2,6 +2,7 @@ import { Component, inject } from "@angular/core";
 import { AreaService } from "../area.service";
 import { GENERIC_SERVICE_TOKEN } from "src/app/shared/components/povider/provider";
 import { IndiceGenericoComponent } from "src/app/shared/components/indice-generico/indice-generico.component";
+import { TablaColumna } from "src/app/shared/components/models/tabla-columna";
 
 @Component({
     selector: 'app-indice-area',

--- a/src/app/features/empresa/IEmpresaService.ts
+++ b/src/app/features/empresa/IEmpresaService.ts
@@ -1,0 +1,8 @@
+import { IServiceBase } from "src/app/shared/interfaces/IServiceBase";
+import { empresaDTO, empresaRequestDTO, empresaDetailDTO } from './models/empresa.model';
+import { Observable } from "rxjs";
+
+export interface IEmpresaService extends IServiceBase<empresaDTO, empresaRequestDTO> { 
+
+  getEmpresaDetailDTO(id: string): Observable<empresaDetailDTO>;
+}

--- a/src/app/features/empresa/crear-empresa/crear-empresa.component.html
+++ b/src/app/features/empresa/crear-empresa/crear-empresa.component.html
@@ -1,0 +1,1 @@
+<p>crear-empresa works!</p>,

--- a/src/app/features/empresa/crear-empresa/crear-empresa.component.ts
+++ b/src/app/features/empresa/crear-empresa/crear-empresa.component.ts
@@ -1,0 +1,12 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-crear-empresa',
+  standalone: true,
+  imports: [
+    CommonModule,
+  ],
+  templateUrl: './crear-empresa.component.html',
+})
+export class CrearEmpresaComponent { }

--- a/src/app/features/empresa/editar-empresa/editar-empresa.component.html
+++ b/src/app/features/empresa/editar-empresa/editar-empresa.component.html
@@ -1,0 +1,1 @@
+<p>editar-empresa works!</p>,

--- a/src/app/features/empresa/editar-empresa/editar-empresa.component.ts
+++ b/src/app/features/empresa/editar-empresa/editar-empresa.component.ts
@@ -1,0 +1,12 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-editar-empresa',
+  standalone: true,
+  imports: [
+    CommonModule,
+  ],
+  templateUrl: './editar-empresa.component.html',
+})
+export class EditarEmpresaComponent { }

--- a/src/app/features/empresa/empresa.service.ts
+++ b/src/app/features/empresa/empresa.service.ts
@@ -1,0 +1,26 @@
+import { inject, Injectable } from '@angular/core';
+import { ServiceBase } from 'src/app/shared/ServiceBase.service';
+import { empresaDetailDTO, empresaDTO, empresaRequestDTO } from './models/empresa.model';
+import { IEmpresaService } from './IEmpresaService';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '@environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EmpresaService
+  extends ServiceBase<empresaDTO, empresaRequestDTO>
+  implements IEmpresaService {
+
+  private readonly httpClient = inject(HttpClient);
+  
+  constructor() {
+    super('Empresa')
+  }
+
+  getEmpresaDetailDTO(id: string): Observable<empresaDetailDTO> {
+    return this.httpClient.get<empresaDetailDTO>(`${environment.ApiUrl}/Empresa/detail/${id}`);
+  }
+
+}

--- a/src/app/features/empresa/indice-empresa/indice-empresa.component.html
+++ b/src/app/features/empresa/indice-empresa/indice-empresa.component.html
@@ -1,0 +1,2 @@
+<app-indice-generico titulo="Empresas" rutaCrear="/empresa/crear" rutaEditar="/empresa/editar"
+  [columnas]="columnas"></app-indice-generico>

--- a/src/app/features/empresa/indice-empresa/indice-empresa.component.ts
+++ b/src/app/features/empresa/indice-empresa/indice-empresa.component.ts
@@ -1,0 +1,27 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { IndiceGenericoComponent } from "src/app/shared/components/indice-generico/indice-generico.component";
+import { GENERIC_SERVICE_TOKEN } from 'src/app/shared/components/povider/provider';
+import { EmpresaService } from '../empresa.service';
+import { TablaColumna } from '../../../shared/components/models/tabla-columna';
+
+@Component({
+  selector: 'app-indice-empresa',
+  standalone: true,
+  imports: [
+    CommonModule,
+    IndiceGenericoComponent
+],
+  templateUrl: './indice-empresa.component.html',
+  providers: [
+  {provide: GENERIC_SERVICE_TOKEN, useClass: EmpresaService }
+]
+})
+
+export class IndiceEmpresaComponent {
+
+  columnas: TablaColumna[] = [{
+    key: 'razonSocial',
+    header: 'Nombre de empresa'}]
+
+}

--- a/src/app/features/empresa/lista-empresa/lista-empresa.component.html
+++ b/src/app/features/empresa/lista-empresa/lista-empresa.component.html
@@ -1,0 +1,9 @@
+<app-listado-generico [listado]="empresasList">
+  <ng-container contenido>
+    @for (empresa of empresasList; track $index) {
+    <div>
+      <p>{{$index + 1}} - {{empresa.razonSocial}}</p>
+    </div>
+    }
+  </ng-container>
+</app-listado-generico>

--- a/src/app/features/empresa/lista-empresa/lista-empresa.component.ts
+++ b/src/app/features/empresa/lista-empresa/lista-empresa.component.ts
@@ -1,0 +1,41 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject, OnInit } from '@angular/core';
+import { GENERIC_SERVICE_TOKEN } from 'src/app/shared/components/povider/provider';
+import { EmpresaService } from '../empresa.service';
+import { empresaDTO, empresaRequestDTO } from '../models/empresa.model';
+import { extractErrorsFromApi } from 'src/app/shared/components/functions/extractErrorsFromAPI';
+import { ListadoGenericoComponent } from "src/app/shared/components/listado-generico/listado-generico.component";
+import { IServiceBase } from 'src/app/shared/interfaces/IServiceBase';
+
+@Component({
+  selector: 'app-lista-empresa',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ListadoGenericoComponent
+],
+  templateUrl: './lista-empresa.component.html',
+  providers: [
+    {provide: GENERIC_SERVICE_TOKEN, useClass: EmpresaService }
+  ]
+})
+export class ListaEmpresaComponent implements OnInit {
+  
+  private readonly empresaService = inject(GENERIC_SERVICE_TOKEN) as IServiceBase<empresaDTO, empresaRequestDTO>;
+  empresasList: empresaDTO[] = [];
+  errors: string[] = [];
+  
+  ngOnInit(): void {
+    this.empresaService.getAll().subscribe({
+      next: (response) => {
+        console.log(response);
+        this.empresasList = response;
+      },
+      error: (err) => {
+        this.errors = err;
+        extractErrorsFromApi(err);
+      }  
+    })
+  }
+  
+}

--- a/src/app/features/empresa/models/empresa.model.ts
+++ b/src/app/features/empresa/models/empresa.model.ts
@@ -1,0 +1,24 @@
+import { condicionIvaDTO } from "../../condicionIva/models/condicionIva.models";
+import { rubroDTO } from "../../rubro/models/rubro.model";
+
+export interface empresaDTO {
+  id: string;
+  razonSocial: string;
+}
+
+export interface empresaRequestDTO {
+  razonSocial: string;
+  cuit: string;
+  cuil: string;
+  rubroId: string;
+  condicionIvaId: string;
+}
+
+export interface empresaDetailDTO extends empresaDTO {
+  cuit: string;
+  cuil: string;
+  rubro: rubroDTO;
+  condicionIva: condicionIvaDTO;
+};
+  
+

--- a/src/app/shared/components/indice-generico/indice-generico.component.html
+++ b/src/app/shared/components/indice-generico/indice-generico.component.html
@@ -1,38 +1,31 @@
 <h2>{{titulo}}</h2>
 <app-mostrar-errores [errores]="errores"></app-mostrar-errores>
 
-<button mat-flat-button routerLink="{{rutaCrear}}">Crear nuevo</button>
+<button mat-flat-button [routerLink]="rutaCrear">Crear nuevo</button>
 
 <app-listado-generico [listado]="entities">
   <ng-container contenido>
+    <table mat-table [dataSource]="entities" class="mat-elevation-z8">
 
-    <table mat-table [dataSource]="entities" class="mat-elevation-z8 indice-elementos">
+      <!-- Columnas dinámicas con @for usando el getter -->
+      @for (col of columnasDefinidas; track col.key) {
+      <ng-container [matColumnDef]="col.key">
+        <th mat-header-cell *matHeaderCellDef>{{ col.header }}</th>
+        <td mat-cell *matCellDef="let elemento">{{ elemento[col.key] }}</td>
+      </ng-container>
+      }
 
-      @for (columna of columnasAMostrar; track $index) {
-      @if (columna === 'acciones'){
-
+      <!-- Columna Acciones (fija para todas las entidades) -->
       <ng-container matColumnDef="acciones">
         <th mat-header-cell *matHeaderCellDef>Acciones</th>
         <td mat-cell *matCellDef="let elemento">
-          <a routerLink="{{rutaEditar + '/' + elemento.id}}" mat-flat-button>Editar</a>
-          <button mat-flat-button color="warn" (click)="confirmarEliminacion(elemento.id)">Borrar</button>
+          <a [routerLink]="rutaEditar + '/' + elemento.id" mat-flat-button>Editar</a>
+          <button mat-button color="warn" (click)="confirmarEliminacion(elemento.id)">Eliminar</button>
         </td>
       </ng-container>
-
-      }@else {
-
-      <ng-container matColumnDef="{{columna}}">
-        <th mat-header-cell *matHeaderCellDef>{{columna}}</th>
-        <td mat-cell *matCellDef="let elemento">{{elemento[columna]}}</td>
-      </ng-container>
-
-      }
-      }
 
       <tr mat-header-row *matHeaderRowDef="columnasAMostrar"></tr>
       <tr mat-row *matRowDef="let row; columns: columnasAMostrar"></tr>
     </table>
-
   </ng-container>
-
 </app-listado-generico>

--- a/src/app/shared/components/indice-generico/indice-generico.component.ts
+++ b/src/app/shared/components/indice-generico/indice-generico.component.ts
@@ -9,7 +9,7 @@ import Swal from 'sweetalert2';
 import { MostrarErroresComponent } from "../mostrar-errores/mostrar-errores.component";
 import { GENERIC_SERVICE_TOKEN } from '../povider/provider';
 import { extractErrorsFromApi } from '../functions/extractErrorsFromAPI';
-import { TipoDireccionService } from 'src/app/features/tipoDireccion/tipoDireccion.service';
+import { TablaColumna } from '../models/tabla-columna';
 
 @Component({
     selector: 'app-indice-generico',
@@ -34,7 +34,7 @@ export class IndiceGenericoComponent<TDTO, TRequestDTO> {
   @Input({ required: true }) titulo!: string;
   @Input({ required: true }) rutaCrear!: string;
   @Input({ required: true }) rutaEditar!: string;
-  @Input() columnasAMostrar: string[] = ['nombre', 'acciones'];
+  @Input() columnas: TablaColumna[] = [];
   entities!: TDTO[];
   errores: string[] = [];
 
@@ -52,8 +52,18 @@ export class IndiceGenericoComponent<TDTO, TRequestDTO> {
         this.errores = errores;
       }
     })
-
   }
+
+  get columnasAMostrar(): string[] {
+    return [...this.columnasDefinidas.map(c => c.key), 'acciones'];
+  }
+
+  get columnasDefinidas(): TablaColumna[] {
+  return (this.columnas && this.columnas.length > 0)
+    ? this.columnas
+    : TablaColumna.default();
+  }
+
 
   confirmarEliminacion(id: string): void {
     Swal.fire({

--- a/src/app/shared/components/models/tabla-columna.ts
+++ b/src/app/shared/components/models/tabla-columna.ts
@@ -1,0 +1,16 @@
+export class TablaColumna {
+  key: string;
+  header: string;
+
+  //Definir constructor con parametros opcionales con valores predefinidos
+  constructor(key?: string, header?: string) {
+    this.key = key ?? 'nombre';
+    this.header = header ?? 'Nombre';
+  }
+
+  static default(): TablaColumna[] {
+    return [
+      new TablaColumna('nombre', 'Nombre')
+    ];
+  }
+}

--- a/src/app/shared/menu/menu.component.html
+++ b/src/app/shared/menu/menu.component.html
@@ -1,8 +1,5 @@
 <mat-toolbar>
 
-  <span>
-    <a mat-button routerLink=""><mat-icon>menu</mat-icon>Dashboard</a>
-  </span>
   <div>
     <a mat-button routerLink="area" routerLinkActive="active" [routerLinkActiveOptions]="{exact:true}">Areas</a>
   </div>
@@ -11,12 +8,12 @@
       con (indice)</a>
   </div>
   <div>
-    <a mat-button routerLink="rol" routerLinkActive="active" [routerLinkActiveOptions]="{exact:true}">
-      Roles</a>
+    <a mat-button routerLink="empresa" routerLinkActive="active" [routerLinkActiveOptions]="{exact:true}">
+      Empresas</a>
   </div>
   <div>
-    <a mat-button routerLink="rol/listado" routerLinkActive="active" [routerLinkActiveOptions]="{exact:true}">
-      Roles (indice)</a>
+    <a mat-button routerLink="empresa/listado" routerLinkActive="active" [routerLinkActiveOptions]="{exact:true}">
+      Empresas (indice)</a>
   </div>
 
 </mat-toolbar>


### PR DESCRIPTION
Se utiliza un objeto TablaColumna que define el nombre de la propiedad y el nombre de la columna. Permite que cada componente envie su lista de Nombres de columnas particulares. En caso de instanciarlo y dejarlo por default se definira bajo los nombres de "Nombre" y "Acciones".